### PR TITLE
Bug: 33615

### DIFF
--- a/src/SME.AE.Aplicacao/Consultas/ObterEventosAlunoPorMes/ObterEventosAlunoPorMesQueryHandler.cs
+++ b/src/SME.AE.Aplicacao/Consultas/ObterEventosAlunoPorMes/ObterEventosAlunoPorMesQueryHandler.cs
@@ -53,7 +53,8 @@ namespace SME.AE.Aplicacao.Consultas
 
             if (DateTime.Today < dataInicial)
             {
-                eventos = eventos.Where(e => e.tipo_evento == (int)TipoEvento.ReuniaoResponsaveis);
+                var tiposEventosPermitidos = new int[] { (int)TipoEvento.ReuniaoResponsaveis, (int)TipoEvento.Feriado, (int)TipoEvento.Avaliacao };
+                eventos = eventos.Where(e => tiposEventosPermitidos.Contains(e.tipo_evento));
             }
 
             var eventosResposta = eventos


### PR DESCRIPTION
Ajuste na listagem de eventos que ao considerar a data atual em comparação com dia e mês dos parâmetros, filtrar os eventos além de reunião de responsáveis também feriado e avaliação.