### PR TITLE
fix/43095

### DIFF
--- a/src/SME.AE.Aplicacao/Consultas/LiberacaoBoletim/ObterBimestres/ObterBimestresLiberacaoBoletimQueryHandler.cs
+++ b/src/SME.AE.Aplicacao/Consultas/LiberacaoBoletim/ObterBimestres/ObterBimestresLiberacaoBoletimQueryHandler.cs
@@ -29,6 +29,8 @@ namespace SME.AE.Aplicacao.Consultas.ObterBimestres
             {
                 var json = await resposta.Content.ReadAsStringAsync();
                 bimestres = JsonConvert.DeserializeObject<int[]>(json);
+                if (json.Contains("-99"))
+                    bimestres = new int[] { 1, 2, 3, 4, 0 };
             }
             else
             {


### PR DESCRIPTION
[AB#43095](https://dev.azure.com/amcomgov/c1dcf343-60ee-40b6-a30a-3b9c12c6d220/_workitems/edit/43095)

Correção para retornar todos os bimestres ao invés de -99